### PR TITLE
Fixes reading files without a EOL character at the end

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_size = 2
 # don't trim trailing whitespace for markdown (is used to force line break)
 [*.md]
 trim_trailing_whitespace = false
+
+[test/fixtures/noEOL.yml]
+insert_final_newline = false

--- a/lib/caml.js
+++ b/lib/caml.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var deepExtend = require('deep-extend');
 var DotObject = require('dot-object');
 var fs = require('fs');
+var os = require('os');
 var path = require('path');
 var util = require('util');
 var yamlJs = require('yaml-js');
@@ -146,6 +147,7 @@ function camlize(options) {
     } else {
       yamlString += fs.readFileSync(path.join(options.dir, fileName + ".yml"), 'UTF8');
     }
+    yamlString += os.EOL;
   });
 
   return parse(

--- a/test/fixtures/noEOL.yml
+++ b/test/fixtures/noEOL.yml
@@ -1,0 +1,5 @@
+no:
+  end:
+    of:
+      file: 'inserted'
+# don't insert a EOL!

--- a/test/specs/camlSpec.js
+++ b/test/specs/camlSpec.js
@@ -10,6 +10,8 @@ var empty = fs.readFileSync('test/fixtures/empty.yml', 'utf-8');
 var lists = fs.readFileSync('test/fixtures/lists.yml', 'utf-8');
 var listsJson = fs.readFileSync('test/fixtures/lists.json', 'utf-8');
 var merge = fs.readFileSync('test/fixtures/merge.yml', 'utf-8');
+var noEOL = fs.readFileSync('test/fixtures/noEOL.yml', 'utf-8');
+
 
 describe('Caml', function () {
   describe('#replaceAliases()', function () {
@@ -145,6 +147,15 @@ describe('Caml', function () {
       });
 
       assert.equal(json.this['is.a.test'], "for.the.separator");
+    });
+    it('shouldnt break on files without a EOL char at the end', function () {
+      caml.camlize({
+        dir: "test/fixtures",
+        files: [
+          "noEOL", "lists"
+        ]
+      });
+
     });
   });
 });


### PR DESCRIPTION
Fixes a crash when no EOL character at the end of one of the files to be merged
