### PR TITLE
Improve quote support in sanitize

### DIFF
--- a/lib/caml.js
+++ b/lib/caml.js
@@ -95,6 +95,7 @@ function sanitize(yamlString) {
 
       var key = line.slice(0, colonIdx);
       var value = line.slice(colonIdx + 1);
+      var quoteMatch;
 
       while (quoteMatch = key.match(/["']/)) {
         var quote = quoteMatch[0];

--- a/lib/caml.js
+++ b/lib/caml.js
@@ -84,33 +84,30 @@ function replaceVariables(yamlLines) {
  * @returns {*}
  */
 function sanitize(yamlString) {
-  var yaml = yamlString.split('\n');
-  var yamlLinesSanitized = [];
+  return yamlString.split('\n')
+    .map(function (line) {
+      var enclosedDottedMatch = line.trim().match(/[",'].*\..*[",']:\s/);
+      var rawDottedMatch = line.trim().match(/.*\..*:\s/);
 
-  yaml.forEach(function (line) {
-    var enclosedDottedMatch = line.trim().match(/[",'].*\..*[",']:\s/);
-    var rawDottedMatch = line.trim().match(/.*\..*:\s/);
+      if (enclosedDottedMatch) {
+        var enclosedSubstituted = line.replace(enclosedDottedMatch[0],
+          enclosedDottedMatch[0]
+            .replace(/[",']/g, '')          // Strip " or ' from the keys
+            .replace(/\./g, DOT_SUBSTITUTE) // Replace . by DOT_SUBSTITUTE in "" keys
+        );
 
-    if (enclosedDottedMatch) {
-      var enclosedSubstituted = line.replace(enclosedDottedMatch[0],
-        enclosedDottedMatch[0]
-          .replace(/[",']/g, '')          // Strip " or ' from the keys
-          .replace(/\./g, DOT_SUBSTITUTE) // Replace . by DOT_SUBSTITUTE in "" keys
-      );
-
-      yamlLinesSanitized.push(enclosedSubstituted);
-    } else if (rawDottedMatch) {
-      var rawSubstituted = line.replace(rawDottedMatch[0],
-        rawDottedMatch[0]
-          .replace(/\./g, DOT_SUBSTITUTE + DOT_SUBSTITUTE) // Replace . by DOT_SUBSTITUTE + DOT_SUBSTITUTE in raw dotted keys
-      );
-      yamlLinesSanitized.push(rawSubstituted);
-    } else {
-      yamlLinesSanitized.push(line)
-    }
-  });
-
-  return yamlLinesSanitized.join('\n');
+        return enclosedSubstituted;
+      } else if (rawDottedMatch) {
+        var rawSubstituted = line.replace(rawDottedMatch[0],
+          rawDottedMatch[0]
+            .replace(/\./g, DOT_SUBSTITUTE + DOT_SUBSTITUTE) // Replace . by DOT_SUBSTITUTE + DOT_SUBSTITUTE in raw dotted keys
+        );
+        return rawSubstituted;
+      } else {
+        return line;
+      }
+    })
+    .join('\n');
 }
 
 /** Writes out the entire hierarchy in YAML

--- a/lib/caml.js
+++ b/lib/caml.js
@@ -86,13 +86,13 @@ function replaceVariables(yamlLines) {
 function sanitize(yamlString) {
   return yamlString.split('\n')
     .map(function (line) {
-      var enclosedDottedMatch = line.trim().match(/[",'].*\..*[",']:\s/);
+      var enclosedDottedMatch = line.trim().match(/["'].*\..*["']:\s/);
       var rawDottedMatch = line.trim().match(/.*\..*:\s/);
 
       if (enclosedDottedMatch) {
         var enclosedSubstituted = line.replace(enclosedDottedMatch[0],
           enclosedDottedMatch[0]
-            .replace(/[",']/g, '')          // Strip " or ' from the keys
+            .replace(/["']/g, '')          // Strip " or ' from the keys
             .replace(/\./g, DOT_SUBSTITUTE) // Replace . by DOT_SUBSTITUTE in "" keys
         );
 

--- a/lib/caml.js
+++ b/lib/caml.js
@@ -86,26 +86,40 @@ function replaceVariables(yamlLines) {
 function sanitize(yamlString) {
   return yamlString.split('\n')
     .map(function (line) {
-      var enclosedDottedMatch = line.trim().match(/["'].*\..*["']:\s/);
-      var rawDottedMatch = line.trim().match(/.*\..*:\s/);
+      var colonIdx = line.indexOf(':');
 
-      if (enclosedDottedMatch) {
-        var enclosedSubstituted = line.replace(enclosedDottedMatch[0],
-          enclosedDottedMatch[0]
-            .replace(/["']/g, '')          // Strip " or ' from the keys
-            .replace(/\./g, DOT_SUBSTITUTE) // Replace . by DOT_SUBSTITUTE in "" keys
-        );
-
-        return enclosedSubstituted;
-      } else if (rawDottedMatch) {
-        var rawSubstituted = line.replace(rawDottedMatch[0],
-          rawDottedMatch[0]
-            .replace(/\./g, DOT_SUBSTITUTE + DOT_SUBSTITUTE) // Replace . by DOT_SUBSTITUTE + DOT_SUBSTITUTE in raw dotted keys
-        );
-        return rawSubstituted;
-      } else {
+      // not an object -> no escaping needed
+      if (colonIdx === -1) {
         return line;
       }
+
+      var key = line.slice(0, colonIdx);
+      var value = line.slice(colonIdx + 1);
+
+      while (quoteMatch = key.match(/["']/)) {
+        var quote = quoteMatch[0];
+        var startIdx = quoteMatch.index;
+
+        var endIdx = key.indexOf(quote, startIdx + 1);
+
+        if (endIdx === -1) {
+          throw new Error('Key contains incomplete quoted section: "' + line + '"');
+        }
+
+        var quoted = key.slice(startIdx + 1, endIdx);
+
+        if (quoted.match(/['"]/)) {
+          throw new Error('Key cannot contain nested quotes: "' + line + '"');
+        }
+
+        key = key.slice(0, startIdx)
+          + quoted.replace(/\./g, DOT_SUBSTITUTE)
+          + key.slice(endIdx + 1);
+      }
+
+      key = key.replace(/\./g, DOT_SUBSTITUTE + DOT_SUBSTITUTE);
+
+      return key + ':' + value;
     })
     .join('\n');
 }

--- a/test/fixtures/dot-with-nested-quotes.yml
+++ b/test/fixtures/dot-with-nested-quotes.yml
@@ -1,0 +1,2 @@
+foo:
+  "ba'r.b'az": qux

--- a/test/fixtures/dot-with-partly-quoted-key.yml
+++ b/test/fixtures/dot-with-partly-quoted-key.yml
@@ -1,0 +1,1 @@
+foo."bar.baz".qux: Lorem ipsum

--- a/test/fixtures/dot-with-unended-quote.yml
+++ b/test/fixtures/dot-with-unended-quote.yml
@@ -1,0 +1,2 @@
+foo:
+  "bar.baz: qux

--- a/test/specs/camlSpec.js
+++ b/test/specs/camlSpec.js
@@ -38,14 +38,41 @@ describe('Caml', function () {
     var sanitize = readFixture('sanitize');
 
     it('should return an array of prepocessed yaml lines', function () {
-      var yaml = caml.sanitize(sanitize);
-      assert.equal(yaml.split('\n').length, 8);
-
-      var obj = caml.parse(yaml.split('\n'));
+      var obj = caml.camlize({
+        dir: 'test/fixtures',
+        files: [
+          'sanitize'
+        ]
+      });
 
       assert.equal("name", obj['variable.name']);
       assert.equal('test."variable.name"', obj.test['variable.name']);
       assert.equal("test.'other.variable.name'", obj.test['other.variable.name'])
+    });
+
+    it('should fail for uneven quoting in keys', function () {
+      var fixture = readFixture('dot-with-unended-quote');
+      assert.throws(function () {
+        caml.sanitize(fixture);
+      }, /Key contains incomplete quoted section/);
+    });
+
+    it('should fail when nesting quotes in keys', function () {
+      var fixture = readFixture('dot-with-nested-quotes');
+      assert.throws(function () {
+        caml.sanitize(fixture);
+      }, /Key cannot contain nested quotes/);
+    });
+
+    it('should handle partly quoted keys correctly', function () {
+      var json = caml.camlize({
+        dir: 'test/fixtures',
+        files: [
+          'dot-with-partly-quoted-key'
+        ]
+      });
+
+      assert.equal(json.foo['bar.baz'].qux, 'Lorem ipsum');
     });
   });
 

--- a/test/specs/camlSpec.js
+++ b/test/specs/camlSpec.js
@@ -2,19 +2,19 @@ var assert = require('assert');
 var fs = require('fs');
 var caml = require('../../lib/caml');
 
-var a = fs.readFileSync('test/fixtures/a.yml', 'utf-8');
-var b = fs.readFileSync('test/fixtures/b.yml', 'utf-8');
-var c = fs.readFileSync('test/fixtures/c.yml', 'utf-8');
-var deep = fs.readFileSync('test/fixtures/deep.yml', 'utf-8');
-var empty = fs.readFileSync('test/fixtures/empty.yml', 'utf-8');
-var lists = fs.readFileSync('test/fixtures/lists.yml', 'utf-8');
-var listsJson = fs.readFileSync('test/fixtures/lists.json', 'utf-8');
-var merge = fs.readFileSync('test/fixtures/merge.yml', 'utf-8');
-var noEOL = fs.readFileSync('test/fixtures/noEOL.yml', 'utf-8');
-
-function read(fileName) {
-  return fs.readFileSync('test/fixtures/' + fileName + '.yml', 'utf8');
+function readFixture(name, extension) {
+  return fs.readFileSync(`test/fixtures/${name}.${extension || 'yml'}`, 'utf-8');
 }
+
+var a = readFixture('a');
+var b = readFixture('b');
+var c = readFixture('c');
+var deep = readFixture('deep');
+var empty = readFixture('empty');
+var lists = readFixture('lists');
+var listsJson = readFixture('lists', 'json');
+var merge = readFixture('merge');
+var noEOL = readFixture('noEOL');
 
 describe('Caml', function () {
   describe('#replaceAliases()', function () {
@@ -35,7 +35,7 @@ describe('Caml', function () {
   });
 
   describe('#sanitize()', function () {
-    var sanitize = read('sanitize');
+    var sanitize = readFixture('sanitize');
 
     it('should return an array of prepocessed yaml lines', function () {
       var yaml = caml.sanitize(sanitize);

--- a/test/specs/camlSpec.js
+++ b/test/specs/camlSpec.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var caml = require('../../lib/caml');
 
 function readFixture(name, extension) {
-  return fs.readFileSync(`test/fixtures/${name}.${extension || 'yml'}`, 'utf-8');
+  return fs.readFileSync('test/fixtures/' + name + '.' + (extension || 'yml'), 'utf-8');
 }
 
 var a = readFixture('a');


### PR DESCRIPTION
- no longer support weird quoting
- throw on incomplete quoting
- throw on nested quotes
- support using quotes not at the end of a key:
  
  ``` yaml
  foo."bar.baz".qux: Lorem ipsum
  ```
