### PR TITLE
Use _.set + _.toPairs to expand dotted keys instead of dot-object

### DIFF
--- a/lib/caml.js
+++ b/lib/caml.js
@@ -1,7 +1,6 @@
 var _ = require('lodash');
 var assert = require('assert');
 var deepExtend = require('deep-extend');
-var DotObject = require('dot-object');
 var escape = require('escape-string-regexp');
 var fs = require('fs');
 var os = require('os');
@@ -13,7 +12,6 @@ var camlUtil = require('./camlUtil');
 
 var DOT = '.';
 var DOT_SUBSTITUTE = '_DOT_';
-var dotObject = new DotObject(DOT);
 
 // Replaces aliases by the block content of the anchors
 function replaceAliases(yamlLines) {
@@ -214,7 +212,7 @@ function parse(yamlLines) {
     if (yaml[key] !== null) {
       var obj = {};
       obj[key] = yaml[key];
-      result.push(dotObject.object(obj));
+      result.push(expand(obj));
     }
   });
 
@@ -227,15 +225,34 @@ function parse(yamlLines) {
   return JSON.parse(jsonString);
 }
 
+function expand(value) {
+  if (_.isObject(value)) {
+    _.toPairs(value).forEach(function (pair) {
+      if (pair[0].indexOf(DOT) > 0) {
+        delete value[pair[0]];
+        _.set(value, pair[0], pair[1]);
+      }
+      if (_.isObject(pair[1])) {
+        _.set(value, pair[0], expand(pair[1]));
+      } else if (_.isArray(pair[1])) {
+        pair[1] = pair[1].map(function (arrObj) {
+          return expand(arrObj);
+        });
+        _.set(value, pair[0], pair[1]);
+      }
+    });
+  } else if (_.isArray(value)) {
+    value =  value.map(function (arrObj) {
+      return expand(arrObj);
+    });
+  }
+  return value;
+}
+
 function camlize(options) {
   if (!options) {
     return;
   }
-
-  if (options.separator) {
-    dotObject = new DotObject(DOT);
-  }
-
   // Default dir is the current working dir
   options.dir = options.dir || path.join(process.cwd());
   var yamlString = "";

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/kevin-smets/caml#readme",
   "dependencies": {
     "deep-extend": "^0.4.1",
-    "dot-object": "^1.4.1",
     "escape-string-regexp": "^1.0.5",
     "lodash": "^4.13.1",
     "yaml-js": "^0.1.3",


### PR DESCRIPTION
Using lodash introduces support for arrays in key notation, e.g.

```
a.b[0].c
```
