### PR TITLE
Merge array elements. This makes it possible to have such constructs:

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ yarr will be [ "one", "two", "three" ]
 
 If you do not use this pattern, arrays will be handled just like simple values. The last one will overwrite all previous arrays.
 
+#### Merging array elements
+
+Array elements will be merged too. It is possible to extend array elements, but keep in mind same values will be overwritten:
+
+    it.is.an.array:
+      - name: "sheep" 
+        voice: "meeh"
+      - name: "cat"
+        voice: "miaw"
+
+    it.is.an.array[0]:
+      size: "large"
+
+    it.is.an.array[1]:
+      size: "small"
+      
+Which results in the following array elements:
+
+    { name: 'sheep', voice: 'meeh', size: 'large' }
+    { name: 'cat', voice: 'miaw', size: 'small' }
+
 ### Variable substitution
 
 CAML can substitute variables inline. Variables used in the CAML configuration need to be in the following form:

--- a/lib/caml.js
+++ b/lib/caml.js
@@ -1,6 +1,5 @@
 var _ = require('lodash');
 var assert = require('assert');
-var deepExtend = require('deep-extend');
 var escape = require('escape-string-regexp');
 var fs = require('fs');
 var os = require('os');
@@ -215,10 +214,7 @@ function parse(yamlLines) {
       result.push(expand(obj));
     }
   });
-
-  deepExtend.apply(null, result);
-
-  var jsonString = JSON.stringify(result[0]);
+  var jsonString = JSON.stringify(_.merge.apply(null, result));
   // Fix "enclosed.dotted.variables"
   jsonString = jsonString.replace(new RegExp(DOT_SUBSTITUTE, 'g'), '.');
 

--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
   },
   "homepage": "https://github.com/kevin-smets/caml#readme",
   "dependencies": {
-    "deep-extend": "^0.4.1",
-    "escape-string-regexp": "^1.0.5",
-    "lodash": "^4.13.1",
-    "yaml-js": "^0.1.3",
-    "yargs": "^6.0.0"
+    "escape-string-regexp": "1.0.5",
+    "lodash": "4.16.4",
+    "yaml-js": "0.1.4",
+    "yargs": "6.3.0"
   },
   "devDependencies": {
     "istanbul": "^0.4.3",

--- a/test/fixtures/arrays.yml
+++ b/test/fixtures/arrays.yml
@@ -1,0 +1,16 @@
+__definition1: &b
+  b:
+    c: 1
+    d: 2
+    e: "valueE"
+
+it.is.an.array:
+  - a: "valueA"
+  - b: *b
+
+it.is.an.array[1]:
+  c: "newC"
+
+it.is.an.array[1].b:
+  c: "replace"
+  g: "newG"

--- a/test/specs/camlSpec.js
+++ b/test/specs/camlSpec.js
@@ -306,5 +306,15 @@ describe('Caml', function () {
       });
       assert.equal(json.variables.multi[0], 'i should be 1 and 2');
     });
+    it('should merge array elements', function () {
+      var json = caml.camlize({
+        dir: "test/fixtures",
+        files: [
+          "arrays"
+        ]
+      });
+      assert.deepEqual(json.it.is.an.array[0], {a: "valueA"});
+      assert.deepEqual(json.it.is.an.array[1], {b: {c: "replace", d: 2, e: "valueE", g: "newG"}, c: "newC" });
+    });
   });
 });


### PR DESCRIPTION
__definition1: &b
  b:
    c: 1
    d: 2
    e: "valueE"

it.is.an.array:
- a: "valueA"
- b: *b

it.is.an.array[1]:
  c: "newC"

it.is.an.array[1].b:
  c: "replace"
  g: "newG"
